### PR TITLE
option choice misspelled

### DIFF
--- a/coe-cli/docs/readme.md
+++ b/coe-cli/docs/readme.md
@@ -54,7 +54,7 @@ Authentication for tasks is managed using the Azure CLI. Using standard az cli c
 
 ```bash
 az login
-coe aa4am install -c add
+coe aa4am install -c aad
 az logout
 ```
 


### PR DESCRIPTION
correction in -c, --components <component> argument 
supported arguments are "all", "aad", "devops", "environment"
