### PR TITLE
Replace Tokens added on DevOps extension list

### DIFF
--- a/coe-cli/docs/aa4am/before-you-start.md
+++ b/coe-cli/docs/aa4am/before-you-start.md
@@ -85,6 +85,8 @@ Notes:
    - [Power DevOps Tools](https://marketplace.visualstudio.com/items?itemName=WaelHamze.xrm-ci-framework-build-tasks)
 
    - [RegexReplace Azure Pipelines Task](https://marketplace.visualstudio.com/items?itemName=knom.regexreplace-task)
+
+   - [Replace Tokens](https://marketplace.visualstudio.com/items?itemName=qetza.replacetokens)
   
    - [SARIF SAST Scans Tab](https://marketplace.visualstudio.com/items?itemName=sariftools.scans)
 
@@ -93,4 +95,4 @@ Notes:
 Once you have verified the above
 
 1. Determine the install [deployment scenario](./scenarios/readme.md) you are targeting
-1. Complete the [Admin Install](./admin-install.md)
+2. Complete the [Admin Install](./admin-install.md)


### PR DESCRIPTION
Replace Tokens added on DevOps extension list as per Setup guide:
https://github.com/microsoft/coe-starter-kit/blob/main/ALMAcceleratorForAdvancedMakers/SETUPGUIDE.md#install-azure-devops-extensions

Replace Tokens DevOps Extension is required for AA4AM