### PR TITLE
Added integration with VSCode remote containers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Set line endings to avoid detecting changes to every file in GitHub when editing within Docker
+* text=auto eol=lf
+
 # Set line endings to LF, even on Windows. Otherwise, execution within Docker fails.
 # See https://help.github.com/articles/dealing-with-line-endings/
-*.sh text eol=lf
+*.sh text eol=crlf

--- a/coe-cli/.devcontainer/devcontainer.json
+++ b/coe-cli/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/docker-existing-dockerfile
+{
+	"name": "CoE CLI Dev Container",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": []
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}


### PR DESCRIPTION
This PR adds a `.devcontainer` folder within the `cli` to allow contributors/consumers to open the solution in VSCode and automatically open within Docker (see [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers)); if you have the VSCode [Remote Development extension pack](https://aka.ms/vscode-remote/download/extension) and Docker installed, it'll ask you if you'd like to re-open the folder in a remote container. If not, it will assume you want to work locally.

Also made a minor tweak to `.gitattribute` file to avoid GitHub detecting every file as a change when opening solution within a container. It should help facilitate contributions and should keep the PRs cleaner.

Fixes #2072 