### PR TITLE
Align connectionreferencedisplayname w connectorid

### DIFF
--- a/CenterofExcellenceALMAccelerator/SolutionPackage/Other/Customizations.xml
+++ b/CenterofExcellenceALMAccelerator/SolutionPackage/Other/Customizations.xml
@@ -17,8 +17,8 @@
   <CanvasApps />
   <Connectors />
   <connectionreferences>
-    <connectionreference connectionreferencelogicalname="cat_CDSDevOps">
-      <connectionreferencedisplayname>CDS DevOps</connectionreferencedisplayname>
+    <connectionreference connectionreferencelogicalname="cat_sharedcommondataservice">
+      <connectionreferencedisplayname>Microsoft Dataverse (legacy)</connectionreferencedisplayname>
       <connectorid>/providers/Microsoft.PowerApps/apis/shared_commondataservice</connectorid>
       <iscustomizable>1</iscustomizable>
       <statecode>0</statecode>


### PR DESCRIPTION
Align connectionreferencedisplayname and connectorid. Displayname is set to CDS DevOps