### PR TITLE
Update Power Platform Maker SR.xml

### DIFF
--- a/CenterofExcellenceCoreComponents/SolutionPackage/Roles/Power Platform Maker SR.xml
+++ b/CenterofExcellenceCoreComponents/SolutionPackage/Roles/Power Platform Maker SR.xml
@@ -119,5 +119,9 @@
     <RolePrivilege name="prvWritenew_flowapprovalbpf" level="Global" />
     <RolePrivilege name="prvWriteSharePointData" level="Global" />
     <RolePrivilege name="prvWriteWorkflow" level="Global" />
+    <RolePrivilege name="prvCreateNote" level="Basic"/>
+    <RolePrivilege name="prvDeleteNote" level="Basic"/>
+    <RolePrivilege name="prvReadNote" level="Basic"/>
+    <RolePrivilege name="prvWriteNote" level="Basic"/>
   </RolePrivileges>
 </Role>


### PR DESCRIPTION
I believe this change will allow for the closing of this bug:
https://github.com/microsoft/coe-starter-kit/issues/2713

The error is due to the SR Maker role not having access to the Note Table to add attachments to the Canvas App Detail page.