### PR TITLE
Add handling for legacy DevOps URLs

### DIFF
--- a/coe-cli/src/common/environment.ts
+++ b/coe-cli/src/common/environment.ts
@@ -157,7 +157,7 @@ export abstract class Environment {
             if ( urlOrg.hostname.toLowerCase() == "dev.azure.com") {
                 orgName = urlOrg.pathname.split('/')[1]
             }
-            else if (legacyUrlOrgMatch = urlOrg.hostname.match(/^(?<orgName>\w+)\.visualstudio\.com$/iu)) {
+            else if (legacyUrlOrgMatch = urlOrg.hostname.match(/^(?<orgName>[^\.]+)\.visualstudio\.com$/iu)) {
                 ({ orgName } = legacyUrlOrgMatch.groups);
             }
         } catch {

--- a/coe-cli/src/common/environment.ts
+++ b/coe-cli/src/common/environment.ts
@@ -152,9 +152,13 @@ export abstract class Environment {
         let orgName = typeof args === "string" ? args : args.organizationName
         try {
             let urlOrg = new url.URL(orgName)
+            let legacyUrlOrgMatch;
             
             if ( urlOrg.hostname.toLowerCase() == "dev.azure.com") {
                 orgName = urlOrg.pathname.split('/')[1]
+            }
+            else if (legacyUrlOrgMatch = urlOrg.hostname.match(/^(?<orgName>\w+)\.visualstudio\.com$/iu)) {
+                ({ orgName } = legacyUrlOrgMatch.groups);
             }
         } catch {
 


### PR DESCRIPTION
In the `coe-cli` the devops organization name is not handled when the Azure DevOps organization is using the legacy URL format `<orgName>.visualstudio.com`.

Previous to this PR, the `getDevOpsUrl` function will return `https://dev.azure.com//` (i.e. the `orgName` path-segment is empty) if the input to the function uses the legacy URL format.

This PR uses a regex to extract the organization name from whatever comes before the first period character in the hostname. The remaining host name (after the organization name) must case-insensitively match `.visualstudio.com`.

Even if the organization is using the legacy URL format in its settings, it is always safe to use the new format `https://dev.azure.com/<orgName>`. Therefore, the `getDevOpsUrl` function can safely continue to always return the new URL format, it will simply be aware of the legacy format when parsing the inputs.

fixes #3538 

/cc @mikefactorial 

*I have tested this code change with success in our own organization which uses the legacy format. When doing so the Pipeline setup as described in #3538 completes all steps successfully.*