### PR TITLE
Installed pwsh and mounted src

### DIFF
--- a/coe-cli/dockerfile
+++ b/coe-cli/dockerfile
@@ -18,6 +18,7 @@ WORKDIR /coe-cli
 COPY --from=base /coe-cli/built /coe-cli/built
 ADD ./docs ./docs
 ADD ./coe ./coe
+ADD ./src ./src
 ADD ./config ./config
 ADD ./package.json ./package.json
 ENV ALPINE_MIRROR "http://dl-cdn.alpinelinux.org/alpine"
@@ -25,4 +26,38 @@ RUN echo "${ALPINE_MIRROR}/edge/main" >> /etc/apk/repositories
 RUN apk add --no-cache nodejs-current npm --repository="http://dl-cdn.alpinelinux.org/alpine/edge/main"
 RUN npm install --legacy-peer-deps
 RUN npm link
+# install the requirements for Powershell
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+    lttng-ust
+
+# Download the powershell '.tar.gz' archive
+RUN curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.2.6/powershell-7.2.6-linux-alpine-x64.tar.gz -o /tmp/powershell.tar.gz
+
+# Create the target folder where powershell will be placed
+RUN mkdir -p /opt/microsoft/powershell/7
+
+# Expand powershell to the target folder
+RUN tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
+
+# Set execute permissions
+RUN chmod +x /opt/microsoft/powershell/7/pwsh
+
+# Create the symbolic link that points to pwsh
+RUN ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+
 CMD ["bash"]


### PR DESCRIPTION
Fixes #3693 #3679 

Mounted `src` folder in final image so `importpipelinerepo.ps` is available and installed powershell in final image.