### PR TITLE
Updated check for new PAT format

### DIFF
--- a/coe-cli/src/commands/devops.ts
+++ b/coe-cli/src/commands/devops.ts
@@ -1206,6 +1206,7 @@ class DevOpsCommand {
     }
 
     async getGitCommitChanges(args: DevOpsBranchArguments, gitApi: gitm.IGitApi, projectRepo: GitRepository, pipelineRepo: GitRepository, sourceBranch: string, destinationBranch: string, defaultBranch: string, names: string[]): Promise<GitChange[]> {
+        const personalAccessTokenRegexp = /^.{76}AZDO.{4}$/;
         let pipelineProject = args.pipelineProject?.length > 0 ? args.pipelineProject : args.projectName
         let results: GitChange[] = []
 
@@ -1215,7 +1216,7 @@ class DevOpsCommand {
                 'Authorization': `Bearer ${accessToken}`
             }
         }
-        if (accessToken.length === 52) {
+        if (accessToken.length === 52 || personalAccessTokenRegexp.test(accessToken)) {
             config = {
                 headers: {
                     'Authorization': `Basic ${Buffer.from(":" + accessToken).toString('base64')}`


### PR DESCRIPTION
Azure DevOps has implemented a new PAT format that is no longer 52 characters long but 84 characters long with a fixed signature 'AZDO'. To prepare for the transition between the new and old PAT format, I would like to change the PAT checks. We have already changed our documentation on the new PAT format: https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#changes-to-format