### PR TITLE
bugfix for issue 10073

### DIFF
--- a/CenterofExcellenceCoreComponents/SolutionPackage/src/Workflows/AdminSyncTemplatev4Portals-CEAD57C0-A080-EE11-8179-000D3A341FFF.json
+++ b/CenterofExcellenceCoreComponents/SolutionPackage/src/Workflows/AdminSyncTemplatev4Portals-CEAD57C0-A080-EE11-8179-000D3A341FFF.json
@@ -1250,7 +1250,7 @@
                               "actions": {
                                 "AdvancedFormID": {
                                   "type": "Compose",
-                                  "inputs": "@items('Apply_to_each_Advanced_Form')?['adx_webformid']",
+                                  "inputs": "@coalesce(items('Apply_to_each_Advanced_Form')?['adx_webformid'], items('Apply_to_each_Advanced_Form')?['mspp_webformid'])",
                                   "metadata": {
                                     "operationMetadataId": "cd606b33-7ed7-43af-92fd-8afe0bf9e94f"
                                   }
@@ -1293,7 +1293,7 @@
                                     "parameters": {
                                       "organization": "@triggerOutputs()?['body/admin_environmentcdsinstanceurl']",
                                       "entityName": "@if(equals(variables('varPortalSource'), 'EDM'), 'mspp_webformsteps', 'adx_webformsteps')",
-                                      "$filter": "@if(equals(variables('varPortalSource'), 'EDM'), concat('_mspp_webformid_value eq ', outputs('AdvancedFormID'), ' and mspp_entitypermissionsenabled eq false'), concat('_adx_webform_value eq ', outputs('AdvancedFormID'), ' and adx_entitypermissionsenabled eq false'))"
+                                      "$filter": "@if(equals(variables('varPortalSource'), 'EDM'), concat('_mspp_webform_value eq ', outputs('AdvancedFormID'), ' and mspp_entitypermissionsenabled eq false'), concat('_adx_webform_value eq ', outputs('AdvancedFormID'), ' and adx_entitypermissionsenabled eq false'))"
                                     },
                                     "host": {
                                       "apiId": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps",


### PR DESCRIPTION
Added fixes for below issues:

Issue 1: AdvancedFormID value stays empty due to blank value for items('Apply_to_each_Advanced_Form')?['adx_webformid']. Proposed fix: coalesce(items('Apply_to_each_Advanced_Form')?['adx_webformid'], items('Apply_to_each_Advanced_Form')?['mspp_webformid'])
Issue 2: syntax error in lookupvalue Filter rows condition on List Related Advanced Form Steps with Table Permissions Disabled step. _mspp_webformid_value needs to be _mspp_webform_value.